### PR TITLE
Remove spurious parens in C part.

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ Said otherwise:
 ===================
 
 fact.lisp             24 parentheses, braces, brackets, angle-brackets, semi-colons, commas
-fact.c                34 parentheses, braces, brackets, angle-brackets, semi-colons, commas
+fact.c                28 parentheses, braces, brackets, angle-brackets, semi-colons, commas
 
 
 ==== fact.lisp ====
@@ -60,18 +60,18 @@ int fact(int x)
 {
     if(0==x)
     {
-        return(1);
+        return 1;
     }
     else
     {
-        return(x*fact(x-1));
+        return x*fact(x-1);
     }
 }
 
 int main()
 {
    printf("\n%d! = %d\n",42,fact(42));
-   return(0);
+   return 0;
 }
 
 ===================


### PR DESCRIPTION
The example still works, and the argument is a lot stronger without spurious parens in the C part (`return` is not a function call).